### PR TITLE
decoder: add functions to decode 8 & 16 bit integers

### DIFF
--- a/include/nanocbor/nanocbor.h
+++ b/include/nanocbor/nanocbor.h
@@ -243,7 +243,41 @@ int nanocbor_get_uint16(nanocbor_value_t *cvalue, uint16_t *value);
 int nanocbor_get_uint32(nanocbor_value_t *cvalue, uint32_t *value);
 
 /**
+ * @brief Retrieve a signed integer as int8_t from the stream
+ *
+ * If the value at `cvalue` is greater than 8 bit (< -128 or > 127),
+ * error is returned.
+ *
+ * The resulting @p value is undefined if the result is an error condition
+ *
+ * @param[in]   cvalue  CBOR value to decode from
+ * @param[out]  value   returned signed integer
+ *
+ * @return              number of bytes read
+ * @return              negative on error
+ */
+int nanocbor_get_int8(nanocbor_value_t *cvalue, int8_t *value);
+
+/**
+ * @brief Retrieve a signed integer as int16_t from the stream
+ *
+ * If the value at `cvalue` is greater than 16 bit (< -32768 or > 32767),
+ * error is returned.
+ *
+ * The resulting @p value is undefined if the result is an error condition
+ *
+ * @param[in]   cvalue  CBOR value to decode from
+ * @param[out]  value   returned signed integer
+ *
+ * @return              number of bytes read
+ * @return              negative on error
+ */
+int nanocbor_get_int16(nanocbor_value_t *cvalue, int16_t *value);
+
+/**
  * @brief Retrieve a signed integer as int32_t from the stream
+ *
+ * If the value at `cvalue` is greater than 32 bit, error is returned.
  *
  * The resulting @p value is undefined if the result is an error condition
  *

--- a/include/nanocbor/nanocbor.h
+++ b/include/nanocbor/nanocbor.h
@@ -198,7 +198,39 @@ int nanocbor_get_type(const nanocbor_value_t *value);
 bool nanocbor_at_end(const nanocbor_value_t *it);
 
 /**
+ * @brief Retrieve a positive integer as uint8_t from the stream
+ *
+ * If the value at `cvalue` is greater than 8 bit (> 255), error is returned.
+ *
+ * The resulting @p value is undefined if the result is an error condition
+ *
+ * @param[in]   cvalue  CBOR value to decode from
+ * @param[out]  value   returned positive integer
+ *
+ * @return              number of bytes read
+ * @return              negative on error
+ */
+int nanocbor_get_uint8(nanocbor_value_t *cvalue, uint8_t *value);
+
+/**
+ * @brief Retrieve a positive integer as uint16_t from the stream
+ *
+ * If the value at `cvalue` is greater than 16 bit (> 65535), error is returned.
+ *
+ * The resulting @p value is undefined if the result is an error condition
+ *
+ * @param[in]   cvalue  CBOR value to decode from
+ * @param[out]  value   returned positive integer
+ *
+ * @return              number of bytes read
+ * @return              negative on error
+ */
+int nanocbor_get_uint16(nanocbor_value_t *cvalue, uint16_t *value);
+
+/**
  * @brief Retrieve a positive integer as uint32_t from the stream
+ *
+ * If the value at `cvalue` is greater than 32 bit, error is returned.
  *
  * The resulting @p value is undefined if the result is an error condition
  *

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -130,6 +130,28 @@ static int _get_uint64(nanocbor_value_t *cvalue, uint32_t *value, uint8_t max, i
     return (int)(1 + bytes);
 }
 
+static int _get_and_advance_uint8(nanocbor_value_t *cvalue, uint8_t *value,
+                                   int type)
+{
+    uint32_t tmp = 0;
+    int res = _get_uint64(cvalue, &tmp, NANOCBOR_SIZE_BYTE,
+                          type);
+    *value = tmp;
+
+    return _advance_if(cvalue, res);
+}
+
+static int _get_and_advance_uint16(nanocbor_value_t *cvalue, uint16_t *value,
+                                   int type)
+{
+    uint32_t tmp = 0;
+    int res = _get_uint64(cvalue, &tmp, NANOCBOR_SIZE_SHORT,
+                          type);
+    *value = tmp;
+
+    return _advance_if(cvalue, res);
+}
+
 static int _get_and_advance_uint32(nanocbor_value_t *cvalue, uint32_t *value,
                                    int type)
 {
@@ -139,6 +161,16 @@ static int _get_and_advance_uint32(nanocbor_value_t *cvalue, uint32_t *value,
     *value = tmp;
 
     return _advance_if(cvalue, res);
+}
+
+int nanocbor_get_uint8(nanocbor_value_t *cvalue, uint8_t *value)
+{
+    return _get_and_advance_uint8(cvalue, value, NANOCBOR_TYPE_UINT);
+}
+
+int nanocbor_get_uint16(nanocbor_value_t *cvalue, uint16_t *value)
+{
+    return _get_and_advance_uint16(cvalue, value, NANOCBOR_TYPE_UINT);
 }
 
 int nanocbor_get_uint32(nanocbor_value_t *cvalue, uint32_t *value)

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -178,7 +178,8 @@ int nanocbor_get_uint32(nanocbor_value_t *cvalue, uint32_t *value)
     return _get_and_advance_uint32(cvalue, value, NANOCBOR_TYPE_UINT);
 }
 
-int nanocbor_get_int32(nanocbor_value_t *cvalue, int32_t *value)
+static int _get_and_advance_int32(nanocbor_value_t *cvalue, int32_t *value, uint8_t max,
+                                  uint32_t bound)
 {
     int type = nanocbor_get_type(cvalue);
     if (type < 0) {
@@ -187,9 +188,8 @@ int nanocbor_get_int32(nanocbor_value_t *cvalue, int32_t *value)
     int res = NANOCBOR_ERR_INVALID_TYPE;
     if (type == NANOCBOR_TYPE_NINT || type == NANOCBOR_TYPE_UINT) {
         uint32_t intermediate = 0;
-        res = _get_uint64(cvalue, &intermediate,
-                              NANOCBOR_SIZE_WORD, type);
-        if (intermediate > INT32_MAX) {
+        res = _get_uint64(cvalue, &intermediate, max, type);
+        if (intermediate > bound) {
             res = NANOCBOR_ERR_OVERFLOW;
         }
         if (type == NANOCBOR_TYPE_NINT) {
@@ -200,6 +200,31 @@ int nanocbor_get_int32(nanocbor_value_t *cvalue, int32_t *value)
         }
     }
     return _advance_if(cvalue, res);
+}
+
+int nanocbor_get_int8(nanocbor_value_t *cvalue, int8_t *value)
+{
+    int32_t tmp = 0;
+    int res = _get_and_advance_int32(cvalue, &tmp, NANOCBOR_SIZE_BYTE, INT8_MAX);
+
+    *value = tmp;
+
+    return res;
+}
+
+int nanocbor_get_int16(nanocbor_value_t *cvalue, int16_t *value)
+{
+    int32_t tmp = 0;
+    int res = _get_and_advance_int32(cvalue, &tmp, NANOCBOR_SIZE_SHORT, INT16_MAX);
+
+    *value = tmp;
+
+    return res;
+}
+
+int nanocbor_get_int32(nanocbor_value_t *cvalue, int32_t *value)
+{
+    return _get_and_advance_int32(cvalue, value, NANOCBOR_SIZE_WORD, INT32_MAX);
 }
 
 int nanocbor_get_tag(nanocbor_value_t *cvalue, uint32_t *tag)


### PR DESCRIPTION
This adds

 - `nanocbor_get_uint8()`
 - `nanocbor_get_uint16()`
 - `nanocbor_get_int8()`
 - `nanocbor_get_int16()`

to mirror the `nanocbor_get_uint32()` and `nanocbor_get_int32()` functions. 