### PR TITLE
decoder: add functions to decode float & double

### DIFF
--- a/include/nanocbor/nanocbor.h
+++ b/include/nanocbor/nanocbor.h
@@ -228,6 +228,32 @@ int nanocbor_get_uint32(nanocbor_value_t *cvalue, uint32_t *value);
 int nanocbor_get_int32(nanocbor_value_t *cvalue, int32_t *value);
 
 /**
+ * @brief Retrieve a single precision floating point number from the stream
+ *
+ * The resulting @p value is undefined if the result is an error condition
+ *
+ * @param[in]   cvalue  CBOR value to decode from
+ * @param[out]  value   returned float
+ *
+ * @return              number of bytes read
+ * @return              negative on error
+ */
+int nanocbor_get_float(nanocbor_value_t *cvalue, float *value);
+
+/**
+ * @brief Retrieve a double precision floating point number from the stream
+ *
+ * The resulting @p value is undefined if the result is an error condition
+ *
+ * @param[in]   cvalue  CBOR value to decode from
+ * @param[out]  value   returned double
+ *
+ * @return              number of bytes read
+ * @return              negative on error
+ */
+int nanocbor_get_double(nanocbor_value_t *cvalue, double *value);
+
+/**
  * @brief Retrieve a byte string from the stream
  *
  * The resulting @p buf and @p len are undefined if the result is an error

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -283,8 +283,7 @@ void nanocbor_leave_container(nanocbor_value_t *it, nanocbor_value_t *container)
 
 static int _skip_simple(nanocbor_value_t *it)
 {
-    uint64_t tmp;
-    (void)tmp;
+    uint64_t tmp = 0;
     int res = _get_uint64(it, (uint32_t*)&tmp, NANOCBOR_SIZE_LONG,
                           nanocbor_get_type(it));
     return _advance_if(it, res);
@@ -313,8 +312,8 @@ int _skip_limited(nanocbor_value_t *it, uint8_t limit)
     int res = type;
 
     if (type == NANOCBOR_TYPE_BSTR || type == NANOCBOR_TYPE_TSTR) {
-        const uint8_t *tmp;
-        size_t len;
+        const uint8_t *tmp = NULL;
+        size_t len = 0;
         res = _get_str(it, &tmp, &len, type);
     }
     /* map or array */

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -150,6 +150,18 @@ int nanocbor_get_uint32(nanocbor_value_t *cvalue, uint32_t *value)
     return _get_and_advance_uint32(cvalue, value, NANOCBOR_TYPE_UINT);
 }
 
+int nanocbor_get_float(nanocbor_value_t *cvalue, float *value)
+{
+    return _get_and_advance_uint32(cvalue, (uint32_t*)value, NANOCBOR_TYPE_FLOAT);
+}
+
+int nanocbor_get_double(nanocbor_value_t *cvalue, double *value)
+{
+    int res = _get_uint64(cvalue, (uint32_t*)value, NANOCBOR_SIZE_LONG,
+                          NANOCBOR_TYPE_FLOAT);
+    return _advance_if(cvalue, res);
+}
+
 int nanocbor_get_int32(nanocbor_value_t *cvalue, int32_t *value)
 {
     int type = nanocbor_get_type(cvalue);


### PR DESCRIPTION
Looks like we can just re-interprete integers of the same size.