### PR TITLE
encoder: add nanocbor_put_tstrn()

### DIFF
--- a/include/nanocbor/nanocbor.h
+++ b/include/nanocbor/nanocbor.h
@@ -596,6 +596,17 @@ int nanocbor_put_bstr(nanocbor_encoder_t *enc, const uint8_t *str, size_t len);
 int nanocbor_put_tstr(nanocbor_encoder_t *enc, const char *str);
 
 /**
+ * @brief Copy n bytes of a text string with indicator into the encoder buffer
+ *
+ * @param[in]   enc     Encoder context
+ * @param[in]   str     text string to encode
+ * @param[in]   len     number of string bytes to copy
+ *
+ * @return              number of bytes written
+ */
+int nanocbor_put_tstrn(nanocbor_encoder_t *enc, const char *str, size_t len);
+
+/**
  * @brief Write an array indicator with @p len items
  *
  * It is assumed that the calling code will encode @p len items after calling

--- a/src/encoder.c
+++ b/src/encoder.c
@@ -148,6 +148,12 @@ int nanocbor_put_tstr(nanocbor_encoder_t *enc, const char *str)
     return _put_bytes(enc, (const uint8_t *)str, len);
 }
 
+int nanocbor_put_tstrn(nanocbor_encoder_t *enc, const char *str, size_t len)
+{
+    nanocbor_fmt_tstr(enc, len);
+    return _put_bytes(enc, (const uint8_t *)str, len);
+}
+
 int nanocbor_put_bstr(nanocbor_encoder_t *enc, const uint8_t *str, size_t len)
 {
     nanocbor_fmt_bstr(enc, len);


### PR DESCRIPTION
Often it is useful to write only parts of a string or a non-null terminated string (e.g. obtained from `nanocbor_get_tstr()`.

`nanocbor_put_tstr()` does not work for this as expects a terminating NULL byte.

Introduce a nanocbor_put_tstrn() function that copies a user defined number of bytes.