### PR TITLE
bug fixes for indefinite containers

### DIFF
--- a/include/nanocbor/nanocbor.h
+++ b/include/nanocbor/nanocbor.h
@@ -89,6 +89,7 @@ extern "C" {
 #define NANOCBOR_SIZE_WORD          26U /**< Value contained in a word */
 #define NANOCBOR_SIZE_LONG          27U /**< Value contained in a long */
 #define NANOCBOR_SIZE_INDEFINITE    31U /**< Indefinite sized container */
+#define NANOCBOR_END_MARKER         (0xFFU) /**< Indefinite end */
 /** @} */
 
 /**

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -279,7 +279,7 @@ int _enter_container(nanocbor_value_t *it, nanocbor_value_t *container,
     container->end = it->end;
     container->remaining = 0;
 
-    if (_value_match_exact(it, type | NANOCBOR_VALUE_MASK) == 1) {
+    if (_value_match_exact(it, (type << NANOCBOR_TYPE_OFFSET) | NANOCBOR_VALUE_MASK) == 1) {
         container->flags = NANOCBOR_DECODER_FLAG_INDEFINITE |
                            NANOCBOR_DECODER_FLAG_CONTAINER;
         container->cur = it->cur;

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -75,8 +75,7 @@ bool nanocbor_at_end(const nanocbor_value_t *it)
     /* The container is at the end when */
     if (_over_end(it) || /* Number of items exhausted */
         /* Indefinite container and the current item is the end marker */
-        ((nanocbor_container_indefinite(it) &&
-         *it->cur == (NANOCBOR_TYPE_FLOAT | NANOCBOR_SIZE_INDEFINITE))) ||
+        ((nanocbor_container_indefinite(it) && *it->cur == (NANOCBOR_END_MARKER))) ||
         /* Or the remaining number of items is zero */
         (nanocbor_in_container(it) && it->remaining == 0)
             ) {


### PR DESCRIPTION
I believe this line:
` *it->cur == (NANOCBOR_TYPE_FLOAT | NANOCBOR_SIZE_INDEFINITE))`

was meant to be this:
` *it->cur == (NANOCBOR_TYPE_FLOAT | NANOCBOR_VALUE_MASK)))`

I however don't like this approach to 'OR' two random things together to get to 0xFF. It costs us nothing to make the code more intuitive and add a new definition.