### PR TITLE
decoder: add missing static qualifier

### DIFF
--- a/src/decoder.c
+++ b/src/decoder.c
@@ -273,7 +273,7 @@ int nanocbor_get_bool(nanocbor_value_t *cvalue, bool *value)
     return res;
 }
 
-int _enter_container(nanocbor_value_t *it, nanocbor_value_t *container,
+static int _enter_container(nanocbor_value_t *it, nanocbor_value_t *container,
                      uint8_t type)
 {
     container->end = it->end;


### PR DESCRIPTION
This fixes compilation with `-Wmissing-prototypes`.

This is the last one needed to make clang 10 with almost all diagnostics happy :-)