### PR TITLE
decoder: add nanocbor_get_key_tstr()

### DIFF
--- a/include/nanocbor/nanocbor.h
+++ b/include/nanocbor/nanocbor.h
@@ -120,6 +120,11 @@ typedef enum {
      * @brief Decoder hits the recursion limit
      */
     NANOCBOR_ERR_RECURSION = -4,
+
+    /**
+     * @brief Decoder could not find the requested entry
+     */
+    NANOCBOR_NOT_FOUND = -5,
 } nanocbor_error_t;
 
 
@@ -318,6 +323,23 @@ int nanocbor_get_bstr(nanocbor_value_t *cvalue, const uint8_t **buf, size_t *len
  * @return              negative on error
  */
 int nanocbor_get_tstr(nanocbor_value_t *cvalue, const uint8_t **buf, size_t *len);
+
+/**
+ * @brief Search for a tstr key in a map.
+ *
+ * The resulting @p value is undefined if @p key was not found.
+ *
+ * @pre @p start is inside a map
+ *
+ * @param[in]   start   pointer to the map to search
+ * @param[in]   key     pointer to the text string key
+ * @param[out]  value   pointer to the tstr value containing @p key if found
+ *
+ * @return              NANOCBOR_OK if @p key was found
+ * @return              negative on error / not found
+ */
+int nanocbor_get_key_tstr(nanocbor_value_t *start, const char *key,
+                          nanocbor_value_t *value);
 
 /**
  * @brief Enter a array type

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -385,3 +385,31 @@ int nanocbor_skip(nanocbor_value_t *it)
 {
     return _skip_limited(it, NANOCBOR_RECURSION_MAX);
 }
+
+int nanocbor_get_key_tstr(nanocbor_value_t *start, const char *key,
+                          nanocbor_value_t *value)
+{
+    int res = NANOCBOR_NOT_FOUND;
+    size_t len = strlen(key);
+    *value = *start;
+
+    while (!nanocbor_at_end(value)) {
+        const uint8_t *s = NULL;
+        size_t s_len = 0;
+
+        if ((res = nanocbor_get_tstr(value, &s, &s_len)) < 0) {
+            break;
+        }
+
+        if (s_len == len && !strncmp(key, (char*)s, len)) {
+            res = NANOCBOR_OK;
+            break;
+        }
+
+        if ((res = nanocbor_skip(value)) < 0) {
+            break;
+        }
+    }
+
+    return res;
+}

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -240,7 +240,7 @@ static int _get_str(nanocbor_value_t *cvalue, const uint8_t **buf, size_t *len, 
     if (cvalue->end - cvalue->cur < 0 || (size_t)(cvalue->end - cvalue->cur) < *len) {
         return NANOCBOR_ERR_END;
     }
-    if (res > 0) {
+    if (res >= 0) {
         *buf = (cvalue->cur) + res;
         _advance(cvalue, (unsigned int)((size_t)res + *len));
         res = NANOCBOR_OK;


### PR DESCRIPTION
Add a convenience function to search for a key in a JSON-like map.

E.g.

	{
		"foo": "bar",
		"baz": [1, 2, 3],
		"end": NULL

	}

If we are only interested in "baz", we can use `nanocbor_get_key_tstr()` and don't have to interate over the elements manually.