### PR TITLE
decoder: prevent underflow in nanocbor_leave_container()

### DIFF
--- a/src/decoder.c
+++ b/src/decoder.c
@@ -322,7 +322,9 @@ int nanocbor_enter_map(nanocbor_value_t *it, nanocbor_value_t *map)
 
 void nanocbor_leave_container(nanocbor_value_t *it, nanocbor_value_t *container)
 {
-    it->remaining--;
+    if (it->remaining) {
+        it->remaining--;
+    }
     if (nanocbor_container_indefinite(container)) {
         it->cur = container->cur + 1;
     }


### PR DESCRIPTION
For indefinite containers `remaining` is 0, meaning that a call to `nanocbor_leave_container()` will create an underflow.

This causes `nanocbor_at_end()` to no longer being able to detect the end of the container.

e.g. trying to decode this message (with garbage padding bytes to trigger the issue) will attempt to decode the map past it's last element.

```bash
echo v2NzZXEBY2NtZIG/ZnJldmVydPX//3NlcQD/AAAAAAA= | base64 -d | bin/fuzztest
```

#### master

```
{
  "seq": 1,
  "cmd": [
    {
      "revert": True,
    },
    ,
Err
  ],
},
,
Err
Done parsing cbor
```

#### this patch

```
{
  "seq": 1,
  "cmd": [
    {
      "revert": True,
    },
  ],
},
,
Err
Done parsing cbor
```