### PR TITLE
decoder: don't decrement remaining in nanocbor_leave_container()

### DIFF
--- a/src/decoder.c
+++ b/src/decoder.c
@@ -345,9 +345,6 @@ int nanocbor_enter_map(nanocbor_value_t *it, nanocbor_value_t *map)
 
 void nanocbor_leave_container(nanocbor_value_t *it, nanocbor_value_t *container)
 {
-    if (it->remaining) {
-        it->remaining--;
-    }
     if (nanocbor_container_indefinite(container)) {
         it->cur = container->cur + 1;
     }

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -34,7 +34,9 @@ void nanocbor_decoder_init(nanocbor_value_t *value,
 static void _advance(nanocbor_value_t *cvalue, unsigned int res)
 {
     cvalue->cur += res;
-    cvalue->remaining--;
+    if (cvalue->remaining) {
+        cvalue->remaining--;
+    }
 }
 
 static int _advance_if(nanocbor_value_t *cvalue, int res)


### PR DESCRIPTION
The remaining value has already been decremented by `_enter_container()`, no need to decrement it twice.

    echo v2NzZXECY2NtZIe/Y2xlZPT/v2VkZWxheRkB9P+/ZGVjaG9pSSdtIGRvbmUh/79jbGVk9f+/ZWRlbGF5GQH0/79jbGVk9P+/ZGVjaG9tTm93IEknbSBkb25lIf9jY2Zn9v8= | base64 -d | bin/fuzztest`


#### master

```
Reading 98 bytes from stdin
advancing
parsing cbor
{
  "seq": 2,
  "cmd": [
    {
      "led": False,
    },
    {
      "delay": 500,
    },
    {
      "echo": "I'm done!",
    },
    {
      "led": True,
    },
  ],
  {
    "delay": 500,
  }: {
    "led": False,
  },
  {
    "echo": "Now I'm done!",
  }: "cfg",
  NULL: Unsupported type
Err
},
Done parsing cbor
```

#### this patch

```
Reading 98 bytes from stdin
advancing
parsing cbor
{
  "seq": 2,
  "cmd": [
    {
      "led": False,
    },
    {
      "delay": 500,
    },
    {
      "echo": "I'm done!",
    },
    {
      "led": True,
    },
    {
      "delay": 500,
    },
    {
      "led": False,
    },
    {
      "echo": "Now I'm done!",
    },
  ],
  "cfg": NULL,
},
Done parsing cbor
```
