### PR TITLE
decoder: fix double decrement for indefinite containers

### DIFF
--- a/src/decoder.c
+++ b/src/decoder.c
@@ -34,7 +34,7 @@ void nanocbor_decoder_init(nanocbor_value_t *value,
 static void _advance(nanocbor_value_t *cvalue, unsigned int res, bool dec_remaining)
 {
     cvalue->cur += res;
-    if (dec_remaining) {
+    if (dec_remaining && cvalue->remaining) {
         cvalue->remaining--;
     }
 }


### PR DESCRIPTION
This fixes early detection of end of container in case
of indefinite containers within definite containers.
Previously, a double decrement of the remaining items
happened:

- first decrement was on nanocbor_leave_container
- second decrement was on _enter_container in case of an
  indefinite container

## Example:

In tests/fuzz, execute 
```console
make test; echo v2NzZXECY2NtZIe/Y2xlZPT/v2VkZWxheRkB9P+/ZGVjaG9pSSdtIGRvbmUh/79jbGVk9f+/ZWRlbGF5GQH0/79jbGVk9P+/ZGVjaG9tTm93IEknbSBkb25lIf9jY2Zn9v8= | base64 -d | ./bin/fuzztest
```

### Result without the fix

```console
Reading 98 bytes from stdin
advancing
parsing cbor
{
  "seq": 2,
  "cmd": [
    {
      "led": False,
    },
    {
      "delay": 500,
    },
    {
      "echo": "I'm done!",
    },
    {
      "led": True,
    },
  ],
  {
    "delay": 500,
  }: {
    "led": False,
  },
  {
    "echo": "Now I'm done!",
  }: "cfg",
  NULL: Unsupported type
Err
},
Done parsing cbor
```

### Result with the fix

```console
Reading 98 bytes from stdin
advancing
parsing cbor
{
  "seq": 2,
  "cmd": [
    {
      "led": False,
    },
    {
      "delay": 500,
    },
    {
      "echo": "I'm done!",
    },
    {
      "led": True,
    },
    {
      "delay": 500,
    },
    {
      "led": False,
    },
    {
      "echo": "Now I'm done!",
    },
  ],
  "cfg": NULL,
},
Done parsing cbor
```