### PR TITLE
 Decoder: Don't decrement remaining in _enter_container 

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,7 +22,7 @@ build_task:
           image: silkeh/clang:7
           image: silkeh/clang:8
       install_libgcc_script:
-        - apt install -y libgcc-7-dev
+        - apt install -y libgcc-9-dev
     - name: gcc
       env:
         CC: gcc

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ OBJ_DIR ?= $(BIN_DIR)/objs
 
 # Only check at issues present for c99 compatible code
 CFLAGS_TIDY ?= -std=c99
-TIDYFLAGS=-checks=* -warnings-as-errors=*
+TIDYFLAGS=-checks=*,-llvmlibc-restrict-system-libc-headers,-bugprone-reserved-identifier,-cert-* -warnings-as-errors=*
 
 CFLAGS_WARN += -Wall -Wextra -pedantic -Werror -Wshadow
-CFLAGS += -fPIC $(CFLAGS_WARN) -I$(INC_DIR) -I$(INC_GLOBAL) -Os
+CFLAGS += -fPIC $(CFLAGS_WARN) -I$(INC_DIR) -I$(INC_GLOBAL) -Og -g3
 
 SRCS ?= $(wildcard $(SRC_DIR)/*.c)
 OBJS ?= $(patsubst $(SRC_DIR)/%.c,$(OBJ_DIR)/%.o,$(SRCS))

--- a/include/nanocbor/nanocbor.h
+++ b/include/nanocbor/nanocbor.h
@@ -379,7 +379,7 @@ int nanocbor_get_key_tstr(nanocbor_value_t *start, const char *key,
  * @return              NANOCBOR_OK on success
  * @return              negative on error
  */
-int nanocbor_enter_array(nanocbor_value_t *it, nanocbor_value_t *array);
+int nanocbor_enter_array(const nanocbor_value_t *it, nanocbor_value_t *array);
 
 /**
  * @brief Enter a map type
@@ -390,7 +390,7 @@ int nanocbor_enter_array(nanocbor_value_t *it, nanocbor_value_t *array);
  * @return              NANOCBOR_OK on success
  * @return              negative on error
  */
-int nanocbor_enter_map(nanocbor_value_t *it, nanocbor_value_t *map);
+int nanocbor_enter_map(const nanocbor_value_t *it, nanocbor_value_t *map);
 
 /**
  * @brief leave the container

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -378,6 +378,7 @@ int nanocbor_skip_simple(nanocbor_value_t *it)
     return _skip_simple(it);
 }
 
+/* NOLINTNEXTLINE(misc-no-recursion): Recursion is limited by design */
 static int _skip_limited(nanocbor_value_t *it, uint8_t limit)
 {
     if (limit == 0) {

--- a/tests/automated/test_decoder.c
+++ b/tests/automated/test_decoder.c
@@ -43,6 +43,10 @@ static void test_decode_map(void)
         0xa1, 0x01, 0x02
     };
 
+    static const uint8_t complex_map_decode[] = {
+        0xa5, 0x01, 0x02, 0x03, 0x80, 0x04, 0x9F, 0xFF, 0x05, 0x9F, 0xff, 0x06, 0xf6
+    };
+
     nanocbor_value_t val;
     nanocbor_value_t cont;
 
@@ -75,6 +79,42 @@ static void test_decode_map(void)
     nanocbor_decoder_init(&val, map_one, sizeof(map_one));
     CU_ASSERT_EQUAL(nanocbor_skip(&val), NANOCBOR_OK);
     CU_ASSERT_EQUAL(nanocbor_at_end(&val), true);
+
+    nanocbor_value_t array;
+    /* Init decoder and start decoding */
+    nanocbor_decoder_init(&val, complex_map_decode, sizeof(complex_map_decode));
+    CU_ASSERT_EQUAL(nanocbor_enter_map(&val, &cont), NANOCBOR_OK);
+    CU_ASSERT(nanocbor_get_uint32(&cont, &tmp) > 0);
+    CU_ASSERT_EQUAL(tmp, 1);
+    CU_ASSERT(nanocbor_get_uint32(&cont, &tmp) > 0);
+    CU_ASSERT_EQUAL(tmp, 2);
+
+    CU_ASSERT(nanocbor_get_uint32(&cont, &tmp) > 0);
+    CU_ASSERT_EQUAL(tmp, 3);
+    CU_ASSERT_EQUAL(nanocbor_enter_array(&cont, &array), NANOCBOR_OK);
+    CU_ASSERT_EQUAL(nanocbor_at_end(&array), true);
+    nanocbor_leave_container(&cont, &array);
+    CU_ASSERT_EQUAL(nanocbor_at_end(&cont), false);
+
+    CU_ASSERT(nanocbor_get_uint32(&cont, &tmp) > 0);
+    CU_ASSERT_EQUAL(tmp, 4);
+    CU_ASSERT_EQUAL(nanocbor_enter_array(&cont, &array), NANOCBOR_OK);
+    CU_ASSERT_EQUAL(nanocbor_at_end(&array), true);
+    nanocbor_leave_container(&cont, &array);
+    CU_ASSERT_EQUAL(nanocbor_at_end(&cont), false);
+
+    CU_ASSERT(nanocbor_get_uint32(&cont, &tmp) > 0);
+    CU_ASSERT_EQUAL(tmp, 5);
+    CU_ASSERT_EQUAL(nanocbor_enter_array(&cont, &array), NANOCBOR_OK);
+    CU_ASSERT_EQUAL(nanocbor_at_end(&array), true);
+    nanocbor_leave_container(&cont, &array);
+    CU_ASSERT_EQUAL(nanocbor_at_end(&cont), false);
+
+    CU_ASSERT(nanocbor_get_uint32(&cont, &tmp) > 0);
+    CU_ASSERT_EQUAL(tmp, 6);
+    CU_ASSERT_EQUAL(nanocbor_at_end(&cont), false);
+    CU_ASSERT_EQUAL(nanocbor_get_null(&cont), NANOCBOR_OK);
+    CU_ASSERT_EQUAL(nanocbor_at_end(&cont), true);
 }
 
 static void test_tag(void)


### PR DESCRIPTION
The `_value_match_exact` call decrements the `nanocbor_value_t::remaining` member when it decodes an indefinite array or map. This should not happen. This PR adds `const` to the outer `nanocbor_value_t` argument of the enter container functions and makes sure that they are not modified in the functions.

This should fix the issue described in #52 and #53.

A test to ensure to test the (non-)indefinite maps/arrays in a mixed scenario is added.