### PR TITLE
Decoder: Fix nanocbor_get_tag for tags >= NANOCBOR_SIZE_BYTE

### DIFF
--- a/src/decoder.c
+++ b/src/decoder.c
@@ -125,6 +125,7 @@ static int _get_uint64(const nanocbor_value_t *cvalue, uint32_t *value, uint8_t 
     memcpy(((uint8_t *)&tmp) + sizeof(uint64_t) - bytes, cvalue->cur + 1U, bytes);
     /* NOLINTNEXTLINE: user supplied function */
     tmp = NANOCBOR_BE64TOH_FUNC(tmp);
+    *value = 0;
     memcpy(value, &tmp, bytes);
 
     return (int)(1 + bytes);

--- a/tests/automated/test_decoder.c
+++ b/tests/automated/test_decoder.c
@@ -120,20 +120,20 @@ static void test_decode_map(void)
 static void test_tag(void)
 {
     static const uint8_t arraytag[] = {
-        0x82, 0xc1, 0x01, 0x02
+        0x82, 0xd8, 0x37, 0x01, 0x02
     };
 
     nanocbor_value_t val;
     nanocbor_value_t cont;
 
-    uint32_t tmp = 0;
+    uint32_t tmp = 0x12345678;
 
     nanocbor_decoder_init(&val, arraytag, sizeof(arraytag));
 
     CU_ASSERT_EQUAL(nanocbor_enter_array(&val, &cont), NANOCBOR_OK);
 
     CU_ASSERT_EQUAL(nanocbor_get_tag(&cont, &tmp), NANOCBOR_OK);
-    CU_ASSERT_EQUAL(tmp, 1);
+    CU_ASSERT_EQUAL(tmp, 0x37);
 
     CU_ASSERT(nanocbor_get_uint32(&cont, &tmp) > 0);
     CU_ASSERT_EQUAL(tmp, 1);


### PR DESCRIPTION
If the provided variable tag isn't initialized with 0, MSBs are not cleared by the internal function _get_uint64.