### PR TITLE
encoder: Implement a polymorphic stream interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ The decoder of NanoCBOR should compile to 600-800 bytes on a Cortex-M0+ MCU, dep
 To achieve the small code size, two patterns are used throughout the decode library.
 
  - Every decode call will first check the type and refuse to decode if the CBOR element is not of the required type.
- - Every decode call will, on succesfull decode, advance the decode context to the next CBOR element.
+ - Every decode call will, on successful decode, advance the decode context to the next CBOR element.
 
 This allows using code to call decode functions and check the return code of the function without requiring an if value of type, decode value, advance to next item dance, and requiring only a single call to decode an expected type and advance to the next element.
+
+### Decoding
 
 Start the decoding of a buffer with:
 
@@ -65,8 +67,119 @@ while (!nanocbor_at_end(&map)) {
 }
 ```
 
+### Encoding
 
-### Dependencies:
+NanoCBOR supports encoding via a polymorphic stream interface via function
+pointers. This methods on this interface are:
+
+```
+typedef size_t (*FnStreamLength)(void *stream);
+typedef int (*FnStreamReserve)(void *stream,  size_t len);
+typedef void (*FnStreamInsert)(void *stream, const void *src, size_t n);
+```
+
+Where `FnStreamLength` queries the stream about how many CBOR bytes have been
+provided, `FnStreamReserve` reserves the requested number of bytes within the
+stream, and `FnStreamInsert` moves bytes into the stream. Each of these
+functions accept a `stream` object, which contains the stream state if one is
+needed. This is exactly like the "this" pointer in other object oriented
+languages.
+
+The `memory_buffer.h/c` is the canonical stream encoder, it expected a large
+memory buffer that it can `memcpy` CBOR data into.
+
+Construction of these objects looks like:
+
+```
+uint8_t buf[64];
+memory_encoder stream;
+MemoryStream_Init(&stream, buf, sizeof(buf));
+
+FnStreamLength len_fn = (FnStreamLength)MemoryStream_Length;
+FnStreamReserve res_fn = (FnStreamReserve)MemoryStream_Reserve;
+FnStreamInsert ins_fn = (FnStreamInsert)MemoryStream_Insert;
+
+nanocbor_encoder_t enc = NANOCBOR_ENCODER(&stream, len_fn, res_fn, ins_fn);
+```
+
+With a valid `nanocbor_encoder_t` you can pass it to the `fmt` functions:
+
+```
+nanocbor_fmt_array_indefinite(&enc);
+nanocbor_fmt_float(&enc, 1.75);
+nanocbor_fmt_float(&enc, 1.9990234375);
+nanocbor_fmt_float(&enc, 1.99951171875);
+nanocbor_fmt_float(&enc, 2.0009765625);
+nanocbor_fmt_float(&enc, -1.75);
+nanocbor_fmt_float(&enc, -1.9990234375);
+nanocbor_fmt_float(&enc, -1.99951171875);
+nanocbor_fmt_float(&enc, -2.0009765625);
+nanocbor_fmt_end_indefinite(&enc);
+```
+
+The encoder places bytes in the stream on demand, so after you are done you can
+find your encoded CBOR data within the buffer you created:
+
+```
+size_t len = nanocbor_encoded_len(&enc);
+
+printf("\n");
+for(unsigned int idx=0; idx < len; idx++)
+{
+    printf("%02X", buf[idx]);
+}
+printf("\n");
+```
+
+#### Implementing a new stream
+
+Here is an example of a `stdout` stream and how to use it:
+
+```
+typedef struct stdout_stream {
+  int len;
+} stdout_stream;
+
+void Stdout_Init(stdout_stream *self) {
+  self->len = 0;
+}
+
+size_t Stdout_Length(stdout_stream *self) {
+  return self->len;
+}
+
+int Stdout_Reserve(stdout_stream *self, size_t len) {
+  self->len += len;
+  return (int)len;
+}
+
+void Stdout_Insert(stdout_stream *self, const void *src, size_t n) {
+  const uint8_t *bytes = (const uint8_t *)src;
+  for (size_t i = 0; i < n; ++i) {
+    printf("%02X ", bytes[i]);
+  }
+}
+
+void encode(void) {
+  stdout_stream stream;
+  Stdout_Init(&stream);
+
+  FnStreamLength len_fn = (FnStreamLength)Stdout_Length;
+  FnStreamReserve res_fn = (FnStreamReserve)Stdout_Reserve;
+  FnStreamInsert ins_fn = (FnStreamInsert)Stdout_Insert;
+
+  nanocbor_encoder_t enc = NANOCBOR_ENCODER(&stream, len_fn, res_fn, ins_fn);
+  nanocbor_fmt_array_indefinite(&enc);
+  nanocbor_fmt_float(&enc, 1.75);
+  nanocbor_fmt_float(&enc, 1.9990234375);
+  nanocbor_fmt_float(&enc, 1.99951171875);
+  nanocbor_fmt_float(&enc, 2.0009765625);
+  nanocbor_fmt_end_indefinite(&enc);
+}
+```
+
+
+### Dependencies
 
 Only dependency are two functions to provide endian conversion.
 These are not provided by the library and have to be configured in the header file.

--- a/include/nanocbor/stream_encoders/memory_buffer.h
+++ b/include/nanocbor/stream_encoders/memory_buffer.h
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+#ifndef ENCODER_MEMORY_BUFFER_H
+#define ENCODER_MEMORY_BUFFER_H
+
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct memory_encoder {
+    uint8_t *cur;   /**< Current position in the buffer */
+    uint8_t *end;   /**< end of the buffer                      */
+    size_t len;     /**< Length in bytes of supplied cbor data. Incremented
+                      *  separate from the buffer check  */
+} memory_encoder;
+
+void MemoryStream_Init(memory_encoder *self, uint8_t *buf, size_t len);
+size_t MemoryStream_Length(memory_encoder *self);
+int MemoryStream_Reserve(memory_encoder *self,  size_t len);
+void MemoryStream_Insert(memory_encoder *self, const void *src, size_t n);
+
+#endif

--- a/src/memory_buffer.c
+++ b/src/memory_buffer.c
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: CC0-1.0
+ */
+#include "nanocbor/nanocbor.h"
+#include "nanocbor/stream_encoders/memory_buffer.h"
+#include <string.h>
+
+void MemoryStream_Init(memory_encoder *self, uint8_t *buf, size_t len)
+{
+    self->len = 0;
+    self->cur = buf;
+    self->end = buf + len;
+}
+
+size_t MemoryStream_Length(memory_encoder *self)
+{
+    return self->len;
+}
+
+int MemoryStream_Reserve(memory_encoder *self, size_t len)
+{
+    const int fits = ((size_t)(self->end - self->cur) >= len);
+    self->len += len;
+    return fits ? (int)len : NANOCBOR_ERR_END;
+}
+
+void MemoryStream_Insert(memory_encoder *self, const void *src, size_t n)
+{
+    memcpy(self->cur, src, n);
+    self->cur += n;
+}

--- a/tests/automated/test_encoder.c
+++ b/tests/automated/test_encoder.c
@@ -4,6 +4,7 @@
 
 #include "test.h"
 #include "nanocbor/nanocbor.h"
+#include "nanocbor/stream_encoders/memory_buffer.h"
 #include <math.h>
 #include <float.h>
 #include <CUnit/CUnit.h>
@@ -21,8 +22,14 @@ static void print_bytestr(const uint8_t *bytes, size_t len)
 static void test_encode_float_specials(void)
 {
     uint8_t buf[64];
-    nanocbor_encoder_t enc;
-    nanocbor_encoder_init(&enc, buf, sizeof(buf));
+    memory_encoder stream;
+    MemoryStream_Init(&stream, buf, sizeof(buf));
+
+    FnStreamLength len_fn = (FnStreamLength)MemoryStream_Length;
+    FnStreamReserve res_fn = (FnStreamReserve)MemoryStream_Reserve;
+    FnStreamInsert ins_fn = (FnStreamInsert)MemoryStream_Insert;
+
+    nanocbor_encoder_t enc = NANOCBOR_ENCODER(&stream, len_fn, res_fn, ins_fn);
 
     nanocbor_fmt_array_indefinite(&enc);
     CU_ASSERT_EQUAL(nanocbor_fmt_float(&enc, NAN), 3);
@@ -41,8 +48,14 @@ static void test_encode_float_specials(void)
 static void test_encode_float_to_half(void)
 {
     uint8_t buf[64];
-    nanocbor_encoder_t enc;
-    nanocbor_encoder_init(&enc, buf, sizeof(buf));
+    memory_encoder stream;
+    MemoryStream_Init(&stream, buf, sizeof(buf));
+
+    FnStreamLength len_fn = (FnStreamLength)MemoryStream_Length;
+    FnStreamReserve res_fn = (FnStreamReserve)MemoryStream_Reserve;
+    FnStreamInsert ins_fn = (FnStreamInsert)MemoryStream_Insert;
+
+    nanocbor_encoder_t enc = NANOCBOR_ENCODER(&stream, len_fn, res_fn, ins_fn);
 
     nanocbor_fmt_array_indefinite(&enc);
     CU_ASSERT_EQUAL(nanocbor_fmt_float(&enc, 1.75), 3);
@@ -62,8 +75,14 @@ static void test_encode_float_to_half(void)
 static void test_encode_double_to_float(void)
 {
     uint8_t buf[128];
-    nanocbor_encoder_t enc;
-    nanocbor_encoder_init(&enc, buf, sizeof(buf));
+    memory_encoder stream;
+    MemoryStream_Init(&stream, buf, sizeof(buf));
+
+    FnStreamLength len_fn = (FnStreamLength)MemoryStream_Length;
+    FnStreamReserve res_fn = (FnStreamReserve)MemoryStream_Reserve;
+    FnStreamInsert ins_fn = (FnStreamInsert)MemoryStream_Insert;
+
+    nanocbor_encoder_t enc = NANOCBOR_ENCODER(&stream, len_fn, res_fn, ins_fn);
 
     nanocbor_fmt_array_indefinite(&enc);
     CU_ASSERT_EQUAL(nanocbor_fmt_double(&enc, 1.75), 3);

--- a/tests/encode/main.c
+++ b/tests/encode/main.c
@@ -9,6 +9,7 @@
 #include <unistd.h>
 
 #include "nanocbor/nanocbor.h"
+#include "nanocbor/stream_encoders/memory_buffer.h"
 
 static void _encode(nanocbor_encoder_t *enc)
 {
@@ -33,8 +34,15 @@ static void _encode(nanocbor_encoder_t *enc)
 
 int main(void)
 {
-    nanocbor_encoder_t enc;
-    nanocbor_encoder_init(&enc, NULL, 0);
+    memory_encoder stream;
+
+    MemoryStream_Init(&stream, NULL, 0);
+
+    FnStreamLength len_fn = (FnStreamLength)MemoryStream_Length;
+    FnStreamReserve res_fn = (FnStreamReserve)MemoryStream_Reserve;
+    FnStreamInsert ins_fn = (FnStreamInsert)MemoryStream_Insert;
+
+    nanocbor_encoder_t enc = NANOCBOR_ENCODER(&stream, len_fn, res_fn, ins_fn);
 
     _encode(&enc);
 
@@ -45,7 +53,8 @@ int main(void)
         return -1;
     }
 
-    nanocbor_encoder_init(&enc, buf, required);
+    MemoryStream_Init(&stream, buf, required);
+
     _encode(&enc);
 
     //printf("Bytes: %u\n", (unsigned)nanocbor_encoded_len(&enc));


### PR DESCRIPTION
This commit abstracts the previously-built-in memory buffer encoding with a polymorphic stream interface. The motivation behind this was the desire to stream bytes out piece-meal over a CAN network without requiring an intermediary buffer in a memory-constrained environment.

Thank you for creating this open-source software! 