### PR TITLE
decoder: fix build on AVR

### DIFF
--- a/src/decoder.c
+++ b/src/decoder.c
@@ -397,7 +397,7 @@ static int _decode_half_float(nanocbor_value_t *cvalue, float *value)
         uint32_t significant = tmp & HALF_FRAC_MASK;
         uint32_t exponent = tmp & (HALF_EXP_MASK << HALF_EXP_POS);
 
-        static const uint32_t magic = (FLOAT_EXP_OFFSET - 1) << FLOAT_EXP_POS;
+        static const uint32_t magic = ((uint32_t)FLOAT_EXP_OFFSET - 1) << FLOAT_EXP_POS;
         static const float *fmagic = (float *)&magic;
 
         if (exponent == 0) {


### PR DESCRIPTION
This fixes the build issue on AVR:

```
/home/benpicco/dev/RIOT/build/pkg/nanocbor/src/decoder.c: In function ‘_decode_half_float’:
/home/benpicco/dev/RIOT/build/pkg/nanocbor/src/decoder.c:400:62: error: left shift count >= width of type [-Werror=shift-count-overflow]
         static const uint32_t magic = (FLOAT_EXP_OFFSET - 1) << FLOAT_EXP_POS;
                                                              ^
/home/benpicco/dev/RIOT/build/pkg/nanocbor/src/decoder.c:400:39: error: initializer element is not a constant expression [-Werror]
         static const uint32_t magic = (FLOAT_EXP_OFFSET - 1) << FLOAT_EXP_POS;
                                       ^
cc1: all warnings being treated as errors
```