### PR TITLE
Avoid mutating nanocbor_get_bool() output on error

### DIFF
--- a/src/decoder.c
+++ b/src/decoder.c
@@ -333,14 +333,18 @@ int nanocbor_get_null(nanocbor_value_t *cvalue)
 
 int nanocbor_get_bool(nanocbor_value_t *cvalue, bool *value)
 {
-    *value = false;
     int res = _value_match_exact(cvalue,
                                  NANOCBOR_MASK_FLOAT | NANOCBOR_SIMPLE_FALSE);
-    if (res < 0) {
-        *value = true;
+    if (res >= NANOCBOR_OK) {
+        *value = false;
+    } else {
         res = _value_match_exact(cvalue,
                                  NANOCBOR_MASK_FLOAT | NANOCBOR_SIMPLE_TRUE);
+        if (res >= NANOCBOR_OK) {
+            *value = true;
+        }
     }
+
     return res;
 }
 


### PR DESCRIPTION
Hi!

Currently, `nanocbor_get_bool()` would write the output value even if read is unsuccessful. Would you be willing to accept this change, so that on error it would leave the original value intact? I think it might be commonly useful and expected.

Sorry for not asking in advance, but this change is so small that it's easier to ask with a ready PR.