### PR TITLE
Fix minor typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NanoCBOR
 
 NanoCBOR is a tiny [CBOR](https://tools.ietf.org/html/rfc7049) library aimed at embedded and heavily constrained devices.
-It is optimized for 32 bit architectures but should run fine on 8 bit and 16 bit architectures.
+It is optimized for 32-bit architectures but should run fine on 8-bit and 16-bit architectures.
 NanoCBOR is optimized for decoding known CBOR structures while optimizing the flash footprint of both NanoCBOR and the code using NanoCBOR.
 
 The decoder of NanoCBOR should compile to 600-800 bytes on a Cortex-M0+ MCU, depending on whether floating point decoding is required.
@@ -16,7 +16,7 @@ Furthermore, the tests make use of [CUnit] as test framework.
 
 All of these can usually be found in the package repository of your Linux distribution.
 
-Building NanoCBOR is a two step process. First a build directory has to be created with the necessary Ninja build files:
+Building NanoCBOR is a two-step process. First a build directory has to be created with the necessary Ninja build files:
 
 ```
 meson build
@@ -25,10 +25,10 @@ meson build
 Second step is to compile NanoCBOR:
 
 ```
-ninja -c build
+ninja -C build
 ```
 
-This results into a `libnanocbor.so` file inside the `build` directory and binaries for the examples and tests in their respective directories inside the `build` directory
+This results in a `libnanocbor.so` file inside the `build` directory and binaries for the examples and tests in their respective directories inside the `build` directory.
 
 When including NanoCBOR into a custom project, it is usually sufficient to only include the source and header files into the project, the meson build system used in the repo is not mandatory to use.
 
@@ -37,7 +37,7 @@ When including NanoCBOR into a custom project, it is usually sufficient to only 
 To achieve the small code size, two patterns are used throughout the decode library.
 
  - Every decode call will first check the type and refuse to decode if the CBOR element is not of the required type.
- - Every decode call will, on succesfull decode, advance the decode context to the next CBOR element.
+ - Every decode call will, on successful decode, advance the decode context to the next CBOR element.
 
 This allows using code to call decode functions and check the return code of the function without requiring an if value of type, decode value, advance to next item dance, and requiring only a single call to decode an expected type and advance to the next element.
 
@@ -48,9 +48,9 @@ nanocbor_value_t decoder;
 nanocbor_decoder_init(&decoder, buffer, buffer_len);
 ```
 
-Where `buffer` is an `const uint8_t` array containing an CBOR structure.
+Where `buffer` is a `const uint8_t` array containing a CBOR structure.
 
-To decode an `int32_t` from a cbor structure and bail out if the element is not of the integer type:
+To decode an `int32_t` from a CBOR structure and bail out if the element is not of the integer type:
 
 ```C
 int32_t value = 0;


### PR DESCRIPTION
The only functional change is the typo fix in `ninja -C build`.