### PR TITLE
decoder: let get_simple() return NANOCBOR_OK, not number of bytes

### DIFF
--- a/src/decoder.c
+++ b/src/decoder.c
@@ -360,7 +360,7 @@ int nanocbor_get_simple(nanocbor_value_t *cvalue, uint8_t *value)
     if (res == NANOCBOR_ERR_OVERFLOW) {
         res = NANOCBOR_ERR_INVALID_TYPE;
     }
-    return res;
+    return res > 0 ? NANOCBOR_OK : res;
 }
 
 /* float bit mask related defines */


### PR DESCRIPTION
to match the docs

This aligns with most of the other `nanocbor_get_*` functions that also return `NANOCBOR_OK` instead of the number of bytes read.

However, while looking at this, I noticed the API to be slightly inconsistent as it returns the number of bytes for all number-related decoding functions such as `nanocbor_get_{uint*,int*,float,double}`. Was there a specific reason to do so or could we change those return values as well? In the end, the user shouldn't need to care about the amount of bytes that were consumed for a specific decoder function, right?