### PR TITLE
decoder: always return NANOCBOR_OK instead of bytes read

### DIFF
--- a/include/nanocbor/nanocbor.h
+++ b/include/nanocbor/nanocbor.h
@@ -280,7 +280,7 @@ bool nanocbor_at_end(const nanocbor_value_t *it);
  * @param[in]   cvalue  CBOR value to decode from
  * @param[out]  value   returned positive integer
  *
- * @return              number of bytes read
+ * @return              NANOCBOR_OK on success
  * @return              negative on error
  */
 int nanocbor_get_uint8(nanocbor_value_t *cvalue, uint8_t *value);
@@ -295,7 +295,7 @@ int nanocbor_get_uint8(nanocbor_value_t *cvalue, uint8_t *value);
  * @param[in]   cvalue  CBOR value to decode from
  * @param[out]  value   returned positive integer
  *
- * @return              number of bytes read
+ * @return              NANOCBOR_OK on success
  * @return              negative on error
  */
 int nanocbor_get_uint16(nanocbor_value_t *cvalue, uint16_t *value);
@@ -310,7 +310,7 @@ int nanocbor_get_uint16(nanocbor_value_t *cvalue, uint16_t *value);
  * @param[in]   cvalue  CBOR value to decode from
  * @param[out]  value   returned positive integer
  *
- * @return              number of bytes read
+ * @return              NANOCBOR_OK on success
  * @return              negative on error
  */
 int nanocbor_get_uint32(nanocbor_value_t *cvalue, uint32_t *value);
@@ -325,7 +325,7 @@ int nanocbor_get_uint32(nanocbor_value_t *cvalue, uint32_t *value);
  * @param[in]   cvalue  CBOR value to decode from
  * @param[out]  value   returned positive integer
  *
- * @return              number of bytes read
+ * @return              NANOCBOR_OK on success
  * @return              negative on error
  */
 int nanocbor_get_uint64(nanocbor_value_t *cvalue, uint64_t *value);
@@ -341,7 +341,7 @@ int nanocbor_get_uint64(nanocbor_value_t *cvalue, uint64_t *value);
  * @param[in]   cvalue  CBOR value to decode from
  * @param[out]  value   returned signed integer
  *
- * @return              number of bytes read
+ * @return              NANOCBOR_OK on success
  * @return              negative on error
  */
 int nanocbor_get_int8(nanocbor_value_t *cvalue, int8_t *value);
@@ -357,7 +357,7 @@ int nanocbor_get_int8(nanocbor_value_t *cvalue, int8_t *value);
  * @param[in]   cvalue  CBOR value to decode from
  * @param[out]  value   returned signed integer
  *
- * @return              number of bytes read
+ * @return              NANOCBOR_OK on success
  * @return              negative on error
  */
 int nanocbor_get_int16(nanocbor_value_t *cvalue, int16_t *value);
@@ -372,7 +372,7 @@ int nanocbor_get_int16(nanocbor_value_t *cvalue, int16_t *value);
  * @param[in]   cvalue  CBOR value to decode from
  * @param[out]  value   returned signed integer
  *
- * @return              number of bytes read
+ * @return              NANOCBOR_OK on success
  * @return              negative on error
  */
 int nanocbor_get_int32(nanocbor_value_t *cvalue, int32_t *value);
@@ -387,7 +387,7 @@ int nanocbor_get_int32(nanocbor_value_t *cvalue, int32_t *value);
  * @param[in]   cvalue  CBOR value to decode from
  * @param[out]  value   returned signed integer
  *
- * @return              number of bytes read
+ * @return              NANOCBOR_OK on success
  * @return              negative on error
  */
 int nanocbor_get_int64(nanocbor_value_t *cvalue, int64_t *value);

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -36,10 +36,20 @@ static void _advance(nanocbor_value_t *cvalue, unsigned int res)
     cvalue->remaining--;
 }
 
+/**
+ * @brief Advance @p cvalue and return @ref NANOCBOR_OK if @p res > 0.
+ *        Propagate error otherwise.
+ *
+ * @param    cvalue     CBOR value to advance
+ * @param    res        positive number of bytes to advance, or error code
+ * @return              NANOCBOR_OK on success
+ * @return              negative on error
+ */
 static int _advance_if(nanocbor_value_t *cvalue, int res)
 {
     if (res > 0) {
         _advance(cvalue, (unsigned int)res);
+        return NANOCBOR_OK;
     }
     return res;
 }

--- a/tests/automated/test_decoder.c
+++ b/tests/automated/test_decoder.c
@@ -24,9 +24,9 @@ static void test_decode_indefinite(void)
     CU_ASSERT_EQUAL(nanocbor_container_indefinite(&cont), true);
 
     /* Decode the three values */
-    CU_ASSERT(nanocbor_get_uint32(&cont, &tmp) > 0);
-    CU_ASSERT(nanocbor_get_uint32(&cont, &tmp) > 0);
-    CU_ASSERT(nanocbor_get_uint32(&cont, &tmp) > 0);
+    CU_ASSERT_EQUAL(nanocbor_get_uint32(&cont, &tmp), NANOCBOR_OK);
+    CU_ASSERT_EQUAL(nanocbor_get_uint32(&cont, &tmp), NANOCBOR_OK);
+    CU_ASSERT_EQUAL(nanocbor_get_uint32(&cont, &tmp), NANOCBOR_OK);
 
     CU_ASSERT_EQUAL(nanocbor_get_uint32(&cont, &tmp), NANOCBOR_ERR_END);
     CU_ASSERT_EQUAL(nanocbor_at_end(&cont), true);
@@ -58,9 +58,9 @@ static void test_decode_map(void)
     /* Init the decoder and verify the decoding of the map elements */
     nanocbor_decoder_init(&val, map_one, sizeof(map_one));
     CU_ASSERT_EQUAL(nanocbor_enter_map(&val, &cont), NANOCBOR_OK);
-    CU_ASSERT(nanocbor_get_uint32(&cont, &tmp) > 0);
+    CU_ASSERT_EQUAL(nanocbor_get_uint32(&cont, &tmp), NANOCBOR_OK);
     CU_ASSERT_EQUAL(tmp, 1);
-    CU_ASSERT(nanocbor_get_uint32(&cont, &tmp) > 0);
+    CU_ASSERT_EQUAL(nanocbor_get_uint32(&cont, &tmp), NANOCBOR_OK);
     CU_ASSERT_EQUAL(tmp, 2);
     CU_ASSERT_EQUAL(nanocbor_at_end(&cont), true);
     CU_ASSERT_EQUAL(nanocbor_leave_container(&val, &cont), NANOCBOR_OK);
@@ -80,33 +80,33 @@ static void test_decode_map(void)
     /* Init decoder and start decoding */
     nanocbor_decoder_init(&val, complex_map_decode, sizeof(complex_map_decode));
     CU_ASSERT_EQUAL(nanocbor_enter_map(&val, &cont), NANOCBOR_OK);
-    CU_ASSERT(nanocbor_get_uint32(&cont, &tmp) > 0);
+    CU_ASSERT_EQUAL(nanocbor_get_uint32(&cont, &tmp), NANOCBOR_OK);
     CU_ASSERT_EQUAL(tmp, 1);
-    CU_ASSERT(nanocbor_get_uint32(&cont, &tmp) > 0);
+    CU_ASSERT_EQUAL(nanocbor_get_uint32(&cont, &tmp), NANOCBOR_OK);
     CU_ASSERT_EQUAL(tmp, 2);
 
-    CU_ASSERT(nanocbor_get_uint32(&cont, &tmp) > 0);
+    CU_ASSERT_EQUAL(nanocbor_get_uint32(&cont, &tmp), NANOCBOR_OK);
     CU_ASSERT_EQUAL(tmp, 3);
     CU_ASSERT_EQUAL(nanocbor_enter_array(&cont, &array), NANOCBOR_OK);
     CU_ASSERT_EQUAL(nanocbor_at_end(&array), true);
     CU_ASSERT_EQUAL(nanocbor_leave_container(&cont, &array), NANOCBOR_OK);
     CU_ASSERT_EQUAL(nanocbor_at_end(&cont), false);
 
-    CU_ASSERT(nanocbor_get_uint32(&cont, &tmp) > 0);
+    CU_ASSERT_EQUAL(nanocbor_get_uint32(&cont, &tmp), NANOCBOR_OK);
     CU_ASSERT_EQUAL(tmp, 4);
     CU_ASSERT_EQUAL(nanocbor_enter_array(&cont, &array), NANOCBOR_OK);
     CU_ASSERT_EQUAL(nanocbor_at_end(&array), true);
     CU_ASSERT_EQUAL(nanocbor_leave_container(&cont, &array), NANOCBOR_OK);
     CU_ASSERT_EQUAL(nanocbor_at_end(&cont), false);
 
-    CU_ASSERT(nanocbor_get_uint32(&cont, &tmp) > 0);
+    CU_ASSERT_EQUAL(nanocbor_get_uint32(&cont, &tmp), NANOCBOR_OK);
     CU_ASSERT_EQUAL(tmp, 5);
     CU_ASSERT_EQUAL(nanocbor_enter_array(&cont, &array), NANOCBOR_OK);
     CU_ASSERT_EQUAL(nanocbor_at_end(&array), true);
     CU_ASSERT_EQUAL(nanocbor_leave_container(&cont, &array), NANOCBOR_OK);
     CU_ASSERT_EQUAL(nanocbor_at_end(&cont), false);
 
-    CU_ASSERT(nanocbor_get_uint32(&cont, &tmp) > 0);
+    CU_ASSERT_EQUAL(nanocbor_get_uint32(&cont, &tmp), NANOCBOR_OK);
     CU_ASSERT_EQUAL(tmp, 6);
     CU_ASSERT_EQUAL(nanocbor_at_end(&cont), false);
     CU_ASSERT_EQUAL(nanocbor_get_null(&cont), NANOCBOR_OK);
@@ -129,10 +129,10 @@ static void test_tag(void)
     CU_ASSERT_EQUAL(nanocbor_get_tag(&cont, &tmp), NANOCBOR_OK);
     CU_ASSERT_EQUAL(tmp, 0x37);
 
-    CU_ASSERT(nanocbor_get_uint32(&cont, &tmp) > 0);
+    CU_ASSERT_EQUAL(nanocbor_get_uint32(&cont, &tmp), NANOCBOR_OK);
     CU_ASSERT_EQUAL(tmp, 1);
 
-    CU_ASSERT(nanocbor_get_uint32(&cont, &tmp) > 0);
+    CU_ASSERT_EQUAL(nanocbor_get_uint32(&cont, &tmp), NANOCBOR_OK);
     CU_ASSERT_EQUAL(tmp, 2);
 
     CU_ASSERT_EQUAL(nanocbor_at_end(&cont), true);
@@ -199,13 +199,13 @@ static void test_decode_basic(void)
     nanocbor_decoder_init(&decoder, &byteval, sizeof(byteval));
     CU_ASSERT_EQUAL(nanocbor_get_type(&decoder), NANOCBOR_TYPE_UINT);
     printf("\"val: %u\"\n", value);
-    CU_ASSERT_EQUAL(nanocbor_get_uint32(&decoder, &value), 1);
+    CU_ASSERT_EQUAL(nanocbor_get_uint32(&decoder, &value), NANOCBOR_OK);
     printf("\"val: %u\"\n", value);
     CU_ASSERT_EQUAL(5, value);
 
     int32_t intval = 0;
     nanocbor_decoder_init(&decoder, &byteval, sizeof(byteval));
-    CU_ASSERT_EQUAL(nanocbor_get_int32(&decoder, &intval), 1);
+    CU_ASSERT_EQUAL(nanocbor_get_int32(&decoder, &intval), NANOCBOR_OK);
     CU_ASSERT_EQUAL(5, intval);
 
     const uint8_t decimal_frac[] = { 0xC4, 0x82, 0x21, 0x19, 0x6a, 0xb3 };


### PR DESCRIPTION
For now, number of bytes read are returned for all number-related functions, but not for containers, tags and strings. This PR unifies the behavior across all user-facing functions.

This is an API breaking change. However, we did not come up with a good reason why users of NanoCBOR would be interested in the number of bytes read, especially if they only get this information for part of the API.

Follow-up of https://github.com/bergzand/NanoCBOR/pull/90