### PR TITLE
Fix buffer length check and update return logic

### DIFF
--- a/src/decoder.c
+++ b/src/decoder.c
@@ -306,16 +306,16 @@ static int _get_str(nanocbor_value_t *cvalue, const uint8_t **buf, size_t *len,
     int res = _get_uint64(cvalue, &tmp, NANOCBOR_SIZE_SIZET, type);
     *len = tmp;
 
+    if (res < 0) {
+        return res;
+    }
     if (cvalue->end - cvalue->cur < 0
-        || (size_t)(cvalue->end - cvalue->cur) < *len) {
+        || (size_t)(cvalue->end - cvalue->cur) < (size_t)res + *len) {
         return NANOCBOR_ERR_END;
     }
-    if (res >= 0) {
-        *buf = (cvalue->cur) + res;
-        _advance(cvalue, (unsigned int)((size_t)res + *len));
-        res = NANOCBOR_OK;
-    }
-    return res;
+    *buf = (cvalue->cur) + res;
+    _advance(cvalue, (unsigned int)((size_t)res + *len));
+    return NANOCBOR_OK;
 }
 
 int nanocbor_get_bstr(nanocbor_value_t *cvalue, const uint8_t **buf,


### PR DESCRIPTION
Related fix for https://github.com/bergzand/NanoCBOR/issues/98